### PR TITLE
#5 - React.forwardRef

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -1,12 +1,28 @@
-import React from 'react';
+import React, { useRef, useImperativeHandle } from 'react';
 
 import classes from './Input.module.css';
 
-const Input = (props) => {
+const Input = React.forwardRef((props, ref) => {
+  const inputRef = useRef();
+
+  const activate = () => {
+    inputRef.current.focus();
+  }
+
+  useImperativeHandle(
+    ref,
+    () => {
+      return {
+        focus: activate
+      };
+    }
+  );
+
   return (
     <div className={`${classes.control} ${props.isValid === false ? classes.invalid : ''}`} >
       <label htmlFor={props.id}>{props.label}</label>
       <input
+        ref={inputRef}
         type={props.type}
         id={props.id}
         value={props.value}
@@ -15,6 +31,6 @@ const Input = (props) => {
       />
     </div>
   );
-}
+});
 
 export default Input;

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useReducer, useContext } from 'react';
+import React, { useState, useEffect, useReducer, useContext, useRef } from 'react';
 
 import Card from '../UI/Card/Card';
 import classes from './Login.module.css';
@@ -62,6 +62,9 @@ const Login = (props) => {
     [emailIsValid, passwordIsValid]
   );
 
+  const emailInputRef = useRef();
+  const passwordInputRef = useRef();
+
   const emailChangeHandler = (event) => {
     dispatchEmail({ type: 'USER_INPUT', val: event.target.value });
   };
@@ -80,13 +83,20 @@ const Login = (props) => {
 
   const submitHandler = (event) => {
     event.preventDefault();
-    authCtx.onLogin(emailState.value, passwordState.value);
+    if (formIsValid) {
+      authCtx.onLogin(emailState.value, passwordState.value);
+    } else if (!emailIsValid) {
+      emailInputRef.current.focus();
+    } else {
+      passwordInputRef.current.focus();
+    }
   };
 
   return (
     <Card className={classes.login}>
       <form onSubmit={submitHandler}>
         <Input
+          ref={emailInputRef}
           isValid={emailIsValid}
           type="email"
           id="email"
@@ -96,6 +106,7 @@ const Login = (props) => {
           onBlur={validateEmailHandler}
         />
         <Input
+          ref={passwordInputRef}
           isValid={passwordIsValid}
           type="password"
           id="password"
@@ -105,7 +116,7 @@ const Login = (props) => {
           onBlur={validatePasswordHandler}
         />
         <div className={classes.actions}>
-          <Button type="submit" className={classes.btn} disabled={!formIsValid}>
+          <Button type="submit" className={classes.btn} >
             Login
           </Button>
         </div>


### PR DESCRIPTION
일반적으로 React 에서는 상위 component 에서 state management를 수행한다.

forwardRef을 이용하면 하위 Component 자체를 상위 Component에 직접 전달하여,

상위 Component 에서 하위 Component 내에 ref를 직접 조작할 수 있다.

이는 React를 통하여 DOM을 조작하는 방식이 아니기 때문에 일반적인 경우에는 사용해서 안되고

거의 사용되지 않는다.

다만 포커싱, 스크롤 과 같은 특정 기능에 한하여 아주 예외적으로 유용하게 사용이 가능하다.